### PR TITLE
Fixes for mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test:
 install: $(TARGET)
 	install -m755 $(TARGET) $(PREFIX)/_$(NAME)
 	mkdir -p $(PREFIX_SHARE)/$(NAME)
-	install -m644 -t $(PREFIX_SHARE)/$(NAME)/ $(WRAPPERS)
+	install -m644 $(WRAPPERS) $(PREFIX_SHARE)/$(NAME)/
 	touch $(CONFIG)
 
 uninstall: $(TARGET)
@@ -53,3 +53,4 @@ run:
 
 clean:
 	rm -rf $(ODIR)/*
+	rm *.o

--- a/config.mk
+++ b/config.mk
@@ -1,10 +1,11 @@
 CC ?= gcc
 CFLAGS ?= -Wall -std=gnu99
+UNAME := $(shell uname)
 
 # set prefix according to OS
 ifeq ($(UNAME),Darwin) # Mac OS X
-PREFIX ?= /usr/local
-PREFIX_SHARE ?= /usr/share
+PREFIX ?= /usr/local/bin
+PREFIX_SHARE ?= /usr/local/share
 else # Linux
 PREFIX ?= /usr/bin
 PREFIX_SHARE ?= /usr/share

--- a/src/rc.c
+++ b/src/rc.c
@@ -166,7 +166,7 @@ void rc_store()
     debug("storing points...");
 
     /* truncate and get write permission */
-    RC_FP = freopen(NULL, "w+", RC_FP);
+    RC_FP = freopen(rc_get_file(), "w+", RC_FP);
 
     /* check */
     if (RC_FP == NULL) {


### PR DESCRIPTION
Changes I needed to make to successfully compile and run on macOS:
- Fix the prefix (would otherwise install as `/usr/local/_wd`) (`UNAME` is not a predefined variable in make)
- the default `install` doesn't have the `-t` flag, the new invocation should work in any case
- I always got the error `error opening config`: if `freopen` can't reuse the old file stream it has to open it, but for that the filename need to be passed (hope this is correct)