### PR TITLE
Bash completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,12 +39,13 @@ install: $(TARGET)
 	install -m755 $(TARGET) $(PREFIX)/_$(NAME)
 	mkdir -p $(PREFIX_SHARE)/$(NAME)
 	install -m644 $(WRAPPERS) $(PREFIX_SHARE)/$(NAME)/
-	install -m664 lib/completions/wd.bash_completion $(PREFIX_BASH_COMP)
+	install -m664 lib/completions/wd.bash_completion $(PREFIX_BASH_COMP)/wd.bash_completion
 	touch $(CONFIG)
 
 uninstall: $(TARGET)
 	rm -rf $(PREFIX)/_$(NAME)
 	rm -rf $(PREFIX_SHARE)/$(NAME)
+	rm -f $(PREFIX_BASH_COMP)/wd.bash_completion
 
 
 # misc

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ install: $(TARGET)
 	install -m755 $(TARGET) $(PREFIX)/_$(NAME)
 	mkdir -p $(PREFIX_SHARE)/$(NAME)
 	install -m644 $(WRAPPERS) $(PREFIX_SHARE)/$(NAME)/
+	install -m664 lib/completions/wd.bash_completion $(PREFIX_BASH_COMP)
 	touch $(CONFIG)
 
 uninstall: $(TARGET)

--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ Not yet implemented:
  - [X] Warp directly to subdirectory of point
  - [ ] Overwriting (force flag)
  - [ ] Clean rc-file
- - [ ] Tab completion
+ - [ ] Tab completion (bash is implemented)

--- a/config.mk
+++ b/config.mk
@@ -6,7 +6,7 @@ UNAME := $(shell uname)
 ifeq ($(UNAME),Darwin) # Mac OS X
 PREFIX ?= /usr/local/bin
 PREFIX_SHARE ?= /usr/local/share
-PREFIX_BASH_COMP ?= /usr/local/etc/bash_completion.d/
+PREFIX_BASH_COMP ?= /usr/local/etc/bash_completion.d
 else # Linux
 PREFIX ?= /usr/bin
 PREFIX_SHARE ?= /usr/share

--- a/config.mk
+++ b/config.mk
@@ -6,9 +6,11 @@ UNAME := $(shell uname)
 ifeq ($(UNAME),Darwin) # Mac OS X
 PREFIX ?= /usr/local/bin
 PREFIX_SHARE ?= /usr/local/share
+PREFIX_BASH_COMP ?= /usr/local/etc/bash_completion.d/
 else # Linux
 PREFIX ?= /usr/bin
 PREFIX_SHARE ?= /usr/share
+PREFIX_BASH_COMP ?= /usr/share/bash-completion/completions
 endif
 
 NAME = wd

--- a/lib/completions/wd.bash_completion
+++ b/lib/completions/wd.bash_completion
@@ -1,0 +1,76 @@
+___wd() 
+{
+
+    local cur prev words cword split
+    local command_given command_regex config_path config_opt_regex
+    _init_completion -s || return
+    command_given=false
+
+    config_path=${WD_CONFIG:=~/.warprc}
+
+    #default list of options to complete
+    opts="-a --add -r --remove -l --list -s --show -p --path -h --help -v --version -c --config -q --quiet"
+
+    command_regex='([[:blank:]](-a|--add|-r|--remove|-l|--list|-s|--show|-p|--path|-h|--help|-v|--version))|((-c|--config)[[:blank:]]+(\w|\.)+[[:blank:]]+\w+|(wd|-q|--quiet)[[:blank:]]+\w+)'
+    config_opt_regex='(--config|-c)[[:blank:]]+\w+'
+
+    # if a command is already specified, only allow optional parameters
+    if egrep --quiet "$command_regex" <<< "${words[@]}"; then    # if [[ "${words[@]}" =~ $command_regex[[:blank:]] ]]; then
+        command_given=true
+        opts="-c --config -q --quiet"
+    fi
+
+    # don't complete optional parameters if already specified
+    if [[ "${words[@]}" =~ [[:blank:]](-c|--config)[[:blank:]] ]]; then
+        opts="${opts/-c --config /}"
+    fi
+    if [[ "${words[@]}" =~ [[:blank:]](-q|--quiet)[[:blank:]] ]]; then
+        opts="${opts/-q --quiet/}"
+    fi
+
+    if [[ "${words[@]}" =~ [[:blank:]](-h|--help|-v|--version)[[:blank:]] ]]; then
+        opts=""
+    fi
+
+    # uncomment for debugging
+
+    warpPoints(){
+        local points=$(awk -F ":" '{print $1}' "${config_path}")
+        opts="${opts} ${points}"
+        # COMPREPLY=( $(compgen -W "${points}" -- ${cur}) )
+    }
+
+    # for parameters after commands
+    case "${prev}" in
+        -c|--config)
+            # complete files
+            _filedir
+            return 0
+            ;;
+        wd|-r|--remove|-p|--path)
+            if [[ -z $cur ]]; then
+                opts=""
+            fi
+            ;&
+        -q|--quiet)
+            # complete warp points
+            if [[ command_given = false ]] && [[ -z $cur ]] || [[ $cur != "-"* ]]; then
+                warpPoints
+            fi
+            ;;
+        -a|--add)
+            return 0
+            ;;
+    esac
+
+    if [[ $cword -gt 1 ]] && [[ "${words[cword-2]}" =~ -c|--config ]] && [[ command_given = false ]]; then
+        warpPoints
+    fi
+    # ( set -o posix ; set ) | grep -E "cur|prev|words|cword|command_given|opts|my_test" | less
+
+    # generate the actual suggestion
+    COMPREPLY=($(compgen -W "${opts}" -- ${cur}))  
+    return 0
+}
+
+complete -F ___wd wd

--- a/lib/completions/wd.bash_completion
+++ b/lib/completions/wd.bash_completion
@@ -10,7 +10,7 @@ ___wd()
     #default list of options to complete
     opts="-a --add -r --remove -l --list -s --show -p --path -h --help -v --version -c --config -q --quiet"
 
-    command_regex='(([[:blank:]](-a|--add|-r|--remove|-l|--list|-s|--show|-p|--path|-h|--help|-v|--version))|((-c|--config)[[:blank:]]+(\w|\.)+[[:blank:]]+\w+|(wd|-q|--quiet)[[:blank:]]+\w+))[[:blank:]]'
+    command_regex='(([[:blank:]](-a|--add|-r|--remove|-l|--list|-s|--show|-h|--help|-v|--version))|((-c|--config)[[:blank:]]+(\w|\.)+[[:blank:]]+\w+|(wd|-q|--quiet|-p|--path)[[:blank:]]+\w+))[[:blank:]]'
     config_opt_regex='(--config|-c)[[:blank:]]+\w+'
 
     # if a command is already specified, only allow optional parameters
@@ -32,9 +32,6 @@ ___wd()
     fi
 
 
-
-    # uncomment for debugging
-
     warpPoints(){
         local points=$(awk -F ":" '{print $1}' "${config_path}")
         opts="${opts} ${points}"
@@ -48,7 +45,7 @@ ___wd()
             _filedir
             return 0
             ;;
-        wd|-r|--remove|-p|--path)
+        wd|-r|--remove)
             if [[ -z $cur ]]; then
                 opts=""
             fi
@@ -59,6 +56,10 @@ ___wd()
                 warpPoints
             fi
             ;;
+        -p|--path)
+            opts=""
+            warpPoints
+            ;;
         -a|--add)
             return 0
             ;;
@@ -67,6 +68,8 @@ ___wd()
     if [[ $cword -gt 1 ]] && [[ "${words[cword-2]}" =~ -c|--config ]] && [[ $command_given = false ]]; then
         warpPoints
     fi
+
+    # uncomment for debug output:
     # ( set -o posix ; set ) | grep -E "cur|prev|words|cword|command_given|opts|my_test" | less
 
     # generate the actual suggestion

--- a/lib/completions/wd.bash_completion
+++ b/lib/completions/wd.bash_completion
@@ -1,6 +1,5 @@
 ___wd() 
 {
-
     local cur prev words cword split
     local command_given command_regex config_path config_opt_regex
     _init_completion -s || return
@@ -11,7 +10,7 @@ ___wd()
     #default list of options to complete
     opts="-a --add -r --remove -l --list -s --show -p --path -h --help -v --version -c --config -q --quiet"
 
-    command_regex='([[:blank:]](-a|--add|-r|--remove|-l|--list|-s|--show|-p|--path|-h|--help|-v|--version))|((-c|--config)[[:blank:]]+(\w|\.)+[[:blank:]]+\w+|(wd|-q|--quiet)[[:blank:]]+\w+)'
+    command_regex='(([[:blank:]](-a|--add|-r|--remove|-l|--list|-s|--show|-p|--path|-h|--help|-v|--version))|((-c|--config)[[:blank:]]+(\w|\.)+[[:blank:]]+\w+|(wd|-q|--quiet)[[:blank:]]+\w+))[[:blank:]]'
     config_opt_regex='(--config|-c)[[:blank:]]+\w+'
 
     # if a command is already specified, only allow optional parameters
@@ -31,6 +30,8 @@ ___wd()
     if [[ "${words[@]}" =~ [[:blank:]](-h|--help|-v|--version)[[:blank:]] ]]; then
         opts=""
     fi
+
+
 
     # uncomment for debugging
 
@@ -54,7 +55,7 @@ ___wd()
             ;&
         -q|--quiet)
             # complete warp points
-            if [[ command_given = false ]] && [[ -z $cur ]] || [[ $cur != "-"* ]]; then
+            if [[ $command_given = false && ( -z $cur || $cur != "-"* ) ]]; then
                 warpPoints
             fi
             ;;
@@ -63,7 +64,7 @@ ___wd()
             ;;
     esac
 
-    if [[ $cword -gt 1 ]] && [[ "${words[cword-2]}" =~ -c|--config ]] && [[ command_given = false ]]; then
+    if [[ $cword -gt 1 ]] && [[ "${words[cword-2]}" =~ -c|--config ]] && [[ $command_given = false ]]; then
         warpPoints
     fi
     # ( set -o posix ; set ) | grep -E "cur|prev|words|cword|command_given|opts|my_test" | less

--- a/src/main.c
+++ b/src/main.c
@@ -85,8 +85,8 @@ int parse_args(int argc, char **argv)
 
             static struct option long_options[] =
                 {
-                    {"quiet",   no_argument,       &QUIET_FLAG, 1},
-                    {"version", no_argument,       0,  0 },
+                    {"quiet",   no_argument,       0, 'q'},
+                    {"version", no_argument,       0, 'v'},
                     {"help",    no_argument,       0, 'h'},
                     {"list",    no_argument,       0, 'l'},
                     {"show",    no_argument,       0, 's'},
@@ -97,7 +97,7 @@ int parse_args(int argc, char **argv)
                     {0, 0, 0, 0}
                 };
 
-            c = getopt_long(argc, argv, "hlsc:r:a:p:",
+            c = getopt_long(argc, argv, "hlsqvc:r:a:p:",
                             long_options, &option_index);
 
             if (c == -1)
@@ -105,7 +105,7 @@ int parse_args(int argc, char **argv)
 
             switch (c)
                 {
-                case 0:
+                case 'v':
                     print_version();
                     exit(EXIT_INFO);
                     break;
@@ -174,6 +174,11 @@ int parse_args(int argc, char **argv)
 
                 case '?':
                     // TODO: logging
+                    break;
+
+                case 'q':
+                    QUIET_FLAG = 1;
+                    // TODO: quiet
                     break;
 
                 default:


### PR DESCRIPTION
This adds tab completion for Bash (quite sophisticated, commands, warp points, files/folders with `--config`, one command at max). By default it uses `~/.warprc`, if specified the file pointed to by `WD_CONFIG`.

Minor changes:
- Changed the quiet flag handling (crashed before when specified).
- Added `-v` as an alias for `--version` (so that every command also has a shorthand - I can remove it again if you want).